### PR TITLE
Feature/recaptcha integration

### DIFF
--- a/lib/.buildConfig.dart
+++ b/lib/.buildConfig.dart
@@ -1,0 +1,19 @@
+class BuildConfig {
+  final String recaptchaSiteKey;
+  final String recaptchaSecretKey;
+
+  BuildConfig({
+    required this.recaptchaSiteKey,
+    required this.recaptchaSecretKey,
+  });
+
+  static final BuildConfig instance = BuildConfig(
+    recaptchaSiteKey: _config["recaptchaSiteKey"],
+    recaptchaSecretKey: _config["recaptchaSecretKey"],
+  );
+
+  static const Map<String, dynamic> _config = {
+    "recaptchaSiteKey": "<YOUR RECAPTCHA SITE KEY>",
+    "recaptchaSecretKey": "<YOUR RECAPTCHA SECRET KEY>",
+  };
+}

--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:g_recaptcha_v3/g_recaptcha_v3.dart';
 import 'package:get/get.dart';
 import '../../../routes/app_pages.dart';
 import '../../../widgets/screen_widget.dart';
@@ -9,6 +10,7 @@ class HomeView extends GetView<HomeController> {
 
   @override
   Widget build(BuildContext context) {
+    GRecaptchaV3.hideBadge();
     return GetRouterOutlet.builder(
       builder: (context, delegate, currentRoute) {
         var arg = Get.rootDelegate.arguments();

--- a/lib/app/modules/login/views/login_view.dart
+++ b/lib/app/modules/login/views/login_view.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_oauth_google/firebase_ui_oauth_google.dart';
 import 'package:flutter/material.dart';
+import 'package:g_recaptcha_v3/g_recaptcha_v3.dart';
 import 'package:get/get.dart';
 import '../../../../firebase_options.dart';
 
@@ -51,6 +52,7 @@ class LoginView extends GetView<LoginController> {
   Widget loginScreen(BuildContext context) {
     Widget ui;
     if (!controller.isLoggedIn) {
+      GRecaptchaV3.showBadge();
       ui = !(GetPlatform.isAndroid || GetPlatform.isIOS) && controller.isRobot
           ? recaptcha()
           : SignInScreen(
@@ -93,12 +95,24 @@ class LoginView extends GetView<LoginController> {
   }
 
   Widget recaptcha() {
-    //TODO: Add Recaptcha
     return Scaffold(
-        body: TextButton(
-      onPressed: () => controller.robot = false,
-      child: const Text("Are you a Robot?"),
-    ));
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextButton(
+              onPressed: () async {
+                String? token = await GRecaptchaV3.execute('login'); //--3
+                print(token);
+                controller.robot = false;
+                Get.rootDelegate.toNamed(Screen.LOGIN.route);
+              },
+              child: const Text("I am a human"),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   /// The following actions are useful here:

--- a/lib/app/modules/login/views/login_view.dart
+++ b/lib/app/modules/login/views/login_view.dart
@@ -9,6 +9,7 @@ import 'package:get/get.dart';
 import '../../../../firebase_options.dart';
 
 import '../../../../models/screens.dart';
+import '../../../../services/recaptcha_service.dart';
 import '../../../widgets/login_widgets.dart';
 import '../controllers/login_controller.dart';
 
@@ -102,9 +103,7 @@ class LoginView extends GetView<LoginController> {
           children: [
             TextButton(
               onPressed: () async {
-                String? token = await GRecaptchaV3.execute('login'); //--3
-                print(token);
-                controller.robot = false;
+                await RecaptchaService.to.isNotABot('recaptcha');
                 Get.rootDelegate.toNamed(Screen.LOGIN.route);
               },
               child: const Text("I am a human"),

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -8,7 +8,7 @@ const double defaultPadding = 16.0;
 
 const useEmulator = false;
 
-const useRecaptcha = false;
+const useRecaptcha = true;
 
 const sendMailFromClient =
     true; // set this true if in server using custom claim status

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:g_recaptcha_v3/g_recaptcha_v3.dart';
 import 'package:get/get.dart';
 import 'package:get_storage/get_storage.dart';
 
@@ -15,6 +16,10 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+  if (GetPlatform.isWeb) {
+    bool ready = await GRecaptchaV3.ready("<your site key>"); //--2
+    print("Is Recaptcha ready? $ready");
+  }
 
   runApp(
     GetMaterialApp.router(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,9 +6,11 @@ import 'package:g_recaptcha_v3/g_recaptcha_v3.dart';
 import 'package:get/get.dart';
 import 'package:get_storage/get_storage.dart';
 
+import '.buildConfig.dart';
 import 'app/routes/app_pages.dart';
 import 'firebase_options.dart';
 import 'services/auth_service.dart';
+import 'services/recaptcha_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -17,8 +19,7 @@ void main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
   if (GetPlatform.isWeb) {
-    bool ready = await GRecaptchaV3.ready("<your site key>"); //--2
-    print("Is Recaptcha ready? $ready");
+    await GRecaptchaV3.ready(BuildConfig.instance.recaptchaSiteKey);
   }
 
   runApp(
@@ -29,6 +30,7 @@ void main() async {
       initialBinding: BindingsBuilder(
         () {
           Get.put(AuthService());
+          Get.put(RecaptchaService());
         },
       ),
       getPages: AppPages.routes,

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -9,6 +9,7 @@ import 'package:get/get.dart';
 import '../models/screens.dart';
 import '../constants.dart';
 import '../models/role.dart';
+import 'recaptcha_service.dart';
 
 class AuthService extends GetxService {
   static AuthService get to => Get.find();
@@ -107,7 +108,8 @@ class AuthService extends GetxService {
         .then((value) => print('Successfully sent email verification'));
   }
 
-  void register() {
+  Future<void> register() async {
+    await RecaptchaService.to.isNotABot('register');
     registered.value = true;
     // logout(); // Uncomment if we need to enforce relogin
     final thenTo =

--- a/lib/services/recaptcha_service.dart
+++ b/lib/services/recaptcha_service.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+import 'package:get/get.dart';
+import 'package:http/http.dart' as http;
+import 'package:g_recaptcha_v3/g_recaptcha_v3.dart';
+
+import '../.buildConfig.dart';
+import '../app/modules/login/controllers/login_controller.dart';
+
+class RecaptchaService extends GetxService {
+  static RecaptchaService get to => Get.find();
+  final LoginController loginController = Get.put(LoginController());
+
+  Future<void> isNotABot(String action) async {
+    final token = await GRecaptchaV3.execute(action);
+    final response = await _getVerificationResponse(token!);
+    final isNotRobot = response['score'] >= 0.5;
+
+    if (isNotRobot) {
+      loginController.robot = false;
+    } else {
+      loginController.robot = true;
+    }
+
+    // return isNotRobot;
+
+    // google recaptcha v3 returns a score between 0 and 1, where 0 means bot and 1 means human.
+    // We are considering anything above or equal to 0.5 as human.
+  }
+
+  Future<Map<String, dynamic>> _getVerificationResponse(String token) async {
+    late http.Response response;
+    try {
+      response = await http.get(
+        Uri.parse(
+            'https://www.google.com/recaptcha/api/siteverify?secret=${BuildConfig.instance.recaptchaSecretKey}&response=$token'),
+        headers: {
+          "Access-Control-Allow-Origin":
+              "*", // Required for CORS support to work
+          "Access-Control-Allow-Credentials":
+              "true", // Required for cookies, authorization headers with HTTPS
+          "Access-Control-Allow-Headers":
+              "Origin,Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,locale",
+          "Access-Control-Allow-Methods": "GET",
+        },
+      );
+    } catch (e) {
+      print('Error : $e');
+    }
+
+    return json.decode(response.body);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -373,6 +373,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  g_recaptcha_v3:
+    dependency: "direct main"
+    description:
+      name: g_recaptcha_v3
+      sha256: b493d9bbad64bb4631a2b7bb86f7b4c6c6a3c2b327729c4130b3c95817bedf29
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.6"
   get:
     dependency: "direct main"
     description:
@@ -533,6 +541,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   firebase_remote_config: ^4.4.7
   firebase_analytics: ^10.10.7
   g_recaptcha_v3: ^0.0.6
+  http: ^1.2.1
 
 dev_dependencies: 
   flutter_lints: 3.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   firebase_ui_localizations: ^1.12.0
   firebase_remote_config: ^4.4.7
   firebase_analytics: ^10.10.7
+  g_recaptcha_v3: ^0.0.6
 
 dev_dependencies: 
   flutter_lints: 3.0.2


### PR DESCRIPTION
integrating Google reCAPTCHA v3 into the login flow of our Flutter web application to enhance security against spam and abuse. The reCAPTCHA badge is displayed only on the authentication screens.

Reference Step 7 TODO: Add ReCaptcha to login flow for password authentication for Web only
Used https://pub.dev/packages/g_recaptcha_v3


Steps to follow:
- Install package `g_recaptcha_v3`
- [Create captcha keys](https://www.google.com/recaptcha/admin)
- For development, add localhost as domain in reCaptcha console
- Add the script inside web/index.html - head tag at the top
```
  <script src="https://www.google.com/recaptcha/api.js?render=<your Recaptcha v3 site key>"></script>
```
replace the site key
- Add the site public and private key in `.build_config.dart`


#### Note
Ensure enabling the CORS 
- https://firebase.google.com/docs/storage/web/download-files#cors_configuration
-----------------
- we can call the isNotABot method in Recaptcha service which generates a token and makes an api call which returns a score provided by google saying about how genuine the user is. which sets the robot variable as false if the score is less than 0.5, in order to verify the user the next time the user logs in
-----------------
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/1bf65e66-65cf-410f-bf3b-0928c7a36799">

The captcha details about what are the scores of the person visited the site can be analysed via the [Admin panel](https://www.google.com/recaptcha/admin) once connected
-----------------
Linkedin: https://www.linkedin.com/in/hardiksjain/
