### PR TITLE
fix: bottom navigation current index

### DIFF
--- a/lib/app/routes/screen_extension.dart
+++ b/lib/app/routes/screen_extension.dart
@@ -110,13 +110,13 @@ extension ScreenExtension on Screen {
 
 extension RoleExtension on Role {
   int getCurrentIndexFromRoute(GetNavConfig? currentRoute) {
-    final String? currentLocation = currentRoute?.uri.toString();
+    final String? currentLocation = currentRoute?.uri.path;
     int currentIndex = 0;
-    if (currentLocation != null && currentLocation.startsWith('/home')) {
-      // removinng '/home' from the start of the location
-      final filteredLocation = currentLocation.replaceFirst('/home', '');
+    if (currentLocation != null) {
       currentIndex = tabs.indexWhere((tab) {
-        return filteredLocation.startsWith(tab.path);
+        String parentPath = tab.parent?.path ?? '';
+        String fullPath = '$parentPath${tab.path}';
+        return currentLocation.startsWith(fullPath);
       });
     }
     return (currentIndex > 0) ? currentIndex : 0;

--- a/lib/app/routes/screen_extension.dart
+++ b/lib/app/routes/screen_extension.dart
@@ -113,10 +113,14 @@ extension RoleExtension on Role {
     final String? currentLocation = currentRoute?.uri.toString();
     int currentIndex = 0;
     if (currentLocation != null) {
-      currentIndex =
-          tabs.indexWhere((tab) => currentLocation.endsWith(tab.path));
+      // removinng '/home' from the start of the location
+      final filteredLocation =
+          currentLocation.replaceFirst(RegExp(r'^/home'), '');
+      currentIndex = tabs.indexWhere((tab) {
+        return filteredLocation.startsWith(tab.path);
+      });
     }
-    return (currentIndex >= 0) ? currentIndex : 0;
+    return (currentIndex > 0) ? currentIndex : 0;
   }
 
   void routeTo(int value, GetDelegate delegate) {

--- a/lib/app/routes/screen_extension.dart
+++ b/lib/app/routes/screen_extension.dart
@@ -112,10 +112,9 @@ extension RoleExtension on Role {
   int getCurrentIndexFromRoute(GetNavConfig? currentRoute) {
     final String? currentLocation = currentRoute?.uri.toString();
     int currentIndex = 0;
-    if (currentLocation != null) {
+    if (currentLocation != null && currentLocation.startsWith('/home')) {
       // removinng '/home' from the start of the location
-      final filteredLocation =
-          currentLocation.replaceFirst(RegExp(r'^/home'), '');
+      final filteredLocation = currentLocation.replaceFirst('/home', '');
       currentIndex = tabs.indexWhere((tab) {
         return filteredLocation.startsWith(tab.path);
       });

--- a/lib/app/routes/screen_extension.dart
+++ b/lib/app/routes/screen_extension.dart
@@ -110,13 +110,13 @@ extension ScreenExtension on Screen {
 
 extension RoleExtension on Role {
   int getCurrentIndexFromRoute(GetNavConfig? currentRoute) {
-    final String? currentLocation = currentRoute?.location;
+    final String? currentLocation = currentRoute?.uri.toString();
     int currentIndex = 0;
     if (currentLocation != null) {
       currentIndex =
-          tabs.indexWhere((tab) => currentLocation.startsWith(tab.path));
+          tabs.indexWhere((tab) => currentLocation.endsWith(tab.path));
     }
-    return (currentIndex > 0) ? currentIndex : 0;
+    return (currentIndex >= 0) ? currentIndex : 0;
   }
 
   void routeTo(int value, GetDelegate delegate) {


### PR DESCRIPTION
Fixed current index on page change for bottom nav bar.

- used `uri` instead of `location` as 'location' is deprecated and shouldn't be used.
- changed the condition to compare with the full path along with parent

-----------------
Linkedin: https://www.linkedin.com/in/hardiksjain/